### PR TITLE
Adding --source option to load_mitochondria.pl script

### DIFF
--- a/scripts/DataConversion/mitochondria/load_mitochondria.pl
+++ b/scripts/DataConversion/mitochondria/load_mitochondria.pl
@@ -6,8 +6,6 @@ load_mitochondria.pl
 
 =head1 Description
 
-:-)
-
 Parses mitochondrial genes out of genbank format NC_ file  and writes them to the database specified.
 Can also load the sequence of the chromosome, the corresponding assembly entries and the appropriate attribute types if needed.
 
@@ -16,21 +14,20 @@ Can also load the sequence of the chromosome, the corresponding assembly entries
 NOTE : Do NOT use the --contig flag to supply a name like **AY172335** or **AY172335.1.16299**.
 The script will fail.
 
-
-    perl ensembl-pipeline/scripts/DataConversion/mitochondria/load_mitochondria.pl \
-    -dbhost HOST -dbuser USER -dbport 9999 -dbpass PASS\
-    -dbname DATABASE_NAME \
-    -chromosome MT \
-    -name MT \
-    -scaffold NC_005089 \
-    -clone AY172335 \
-    -toplevel chromosome \
-    -gene_type test\
-    -trna_type test-Mt-tRNA \
-    -rrna_type test-Mt-tRNA \
-    -codon_table 2 \
-    -logic_name gmap_ncbi \
-    -genbank_file $BASE/downloads/sequence.gb
+       perl ensembl-pipeline/scripts/DataConversion/mitochondria/load_mitochondria.pl \
+        -dbhost HOST -dbuser USER -dbport 9999 -dbpass PASS\
+        -dbname DATABASE_NAME  \
+        -chromosome  MT          \
+        -name        MT \
+        -scaffold    NC_005089   \
+        -clone       AY172335  \
+        -toplevel    chromosome  \
+        -gene_type   test\
+        -trna_type   test-Mt-tRNA \
+        -rrna_type   test-Mt-tRNA \
+        -codon_table 2  \
+        -logic_name  gmap_ncbi  \
+        -genbank_file      $BASE/downloads/sequence.gb
 
 
 =head1 Config


### PR DESCRIPTION
## load_mitochondria.pl
### New features
- added --source option to the load_mitochondria.pl script 
- added MIT_SOURCE_NAME  parameter for default source name (ensembl) to config file 
- added some example command line on how to use the script 
### Bugfix
- fixed bug which prevented users to use the --logic_name option to set the logic name of the MT genes directly
