### PR TITLE
Setting gene.source name by command line 

### DIFF
--- a/scripts/DataConversion/mitochondria/MitConf.pm
+++ b/scripts/DataConversion/mitochondria/MitConf.pm
@@ -63,7 +63,11 @@ use vars qw( %MitConf );
   # Types
   MIT_GENE_TYPE => 'protein_coding',
   MIT_TRNA_TYPE => 'Mt_tRNA',
-  MIT_RRNA_TYPE => 'Mt_rRNA', );
+  MIT_RRNA_TYPE => 'Mt_rRNA', 
+
+
+  MIT_SOURCE_NAME => "ensembl",# Set gene.source name 
+);
 
 sub import {
     my ($callpack) = caller(0); # Name of the calling package

--- a/scripts/DataConversion/mitochondria/load_mitochondria.pl
+++ b/scripts/DataConversion/mitochondria/load_mitochondria.pl
@@ -97,6 +97,7 @@ GetOptions( \%opt,
             'trna_type=s',
             'rrna_type=s',
             'codon_table=i',
+            'source=s',         # Allow to set the gene.source by commandline option | MIT_SOURCE_NAME
             'name=s',
             'genbank_file=s',
             'download!',
@@ -121,6 +122,7 @@ if (    $opt{dbhost} && $opt{dbuser}
 
 $MIT_GENBANK_FILE = $opt{genbank_file} if $opt{genbank_file};
 $MIT_LOGIC_NAME   = $opt{logic_name}   if $opt{logic_name};
+$MIT_SOURCE_NAME  = $opt{source}       if $opt{source};
 $MIT_NAME         = $opt{name}         if $opt{name};
 $MIT_TOPLEVEL     = $opt{toplevel}     if $opt{toplevel};
 $MIT_CODON_TABLE  = $opt{codon_table}  if $opt{codon_table};
@@ -516,6 +518,7 @@ for (my $index = 1; $index < $length; $index++) {
       $transcript->analysis($ensembl_analysis);
       $gene->add_Transcript($transcript);
       $gene->canonical_transcript($transcript);
+      $gene->source($MIT_SOURCE_NAME);
       $count++;
     };
     if ($@){


### PR DESCRIPTION
This change allows users to set the gene.source attribute by command line.
It's needed as the current value is currently hard-coded.

If you don't set the --source attribute, the script will default to gene.source =  "ensembl"
(as configured in the MitConf.pm file (MIT_SOURCE_NAME)

Let me know if you have any questions, 

Jan
