### PR TITLE
Fix use vars, removed comma

### DIFF
--- a/modules/Bio/EnsEMBL/Pipeline/Config/BatchQueue.pm.efg_arrays
+++ b/modules/Bio/EnsEMBL/Pipeline/Config/BatchQueue.pm.efg_arrays
@@ -181,7 +181,7 @@
 package Bio::EnsEMBL::Pipeline::Config::BatchQueue;
 
 use strict;
-use vars qw(%Config, @QUEUE_CONFIG);
+use vars qw(%Config @QUEUE_CONFIG);
 
 require "$ENV{'WORK_DIR'}/batch_queue.pm";
 %Config = (


### PR DESCRIPTION
I can't remember whether I have push permission for ensembl-pipeline. Tiny change to example funcgen specific BatchQueue.pm.efg_arrays. Shouldn't affect you guys.
