### PR TITLE
Allow gzipped fasta as input

### DIFF
--- a/scripts/load_seq_region.pl
+++ b/scripts/load_seq_region.pl
@@ -230,7 +230,7 @@ sub parse_fasta{
 
   my $seqio = new Bio::SeqIO(
                              -format=>'Fasta',
-                             -file=>$filename
+                             -file=> $filename =~ /\.gz$/? "gunzip -c $filename | " : $filename
                             );
   
   while ( my $seq = $seqio->next_seq ) 


### PR DESCRIPTION
This adds a tiny new functionality to the script: allow the passed fasta file to be gzipped. 

I have found myself wanting to do this when importing a new species from WormBase, and wanting to refer the script to the FTP directory.

