### PR TITLE
fix wrongly assigned toplevel for component seq_regions

### DIFF
--- a/scripts/set_toplevel.pl
+++ b/scripts/set_toplevel.pl
@@ -219,7 +219,11 @@ sub add_attrib_code {
 sub all_component_ids {
   # get all of the regions that are components of other seq regions (assembly.cmp_seq_region_id)
   my $db = shift;
-  my $sth = $db->dbc->prepare('SELECT distinct cmp_seq_region_id FROM assembly');
+  my $sth = $db->dbc->prepare('SELECT distinct a.cmp_seq_region_id ' .
+                        'FROM assembly a, seq_region sr, coord_system cs ' .
+                        'WHERE a.cmp_seq_region_id = sr.seq_region_id ' .
+                          'AND sr.coord_system_id = cs.coord_system_id ' .
+                          'AND  cs.attrib like "%default_version%" ');
 
   $sth->execute();
 

--- a/scripts/set_toplevel.pl
+++ b/scripts/set_toplevel.pl
@@ -218,12 +218,18 @@ sub add_attrib_code {
 
 sub all_component_ids {
   # get all of the regions that are components of other seq regions (assembly.cmp_seq_region_id)
+  #   and both cmp and asm are from the default cs
   my $db = shift;
   my $sth = $db->dbc->prepare('SELECT distinct a.cmp_seq_region_id ' .
-                        'FROM assembly a, seq_region sr, coord_system cs ' .
-                        'WHERE a.cmp_seq_region_id = sr.seq_region_id ' .
-                          'AND sr.coord_system_id = cs.coord_system_id ' .
-                          'AND  cs.attrib like "%default_version%" ');
+                        'FROM assembly a, ' .
+                          'seq_region sr_a, seq_region sr_c, ' .
+                          'coord_system cs_a, coord_system cs_c ' .
+                        'WHERE a.cmp_seq_region_id = sr_c.seq_region_id ' .
+                          'AND a.asm_seq_region_id = sr_a.seq_region_id ' .
+                          'AND sr_a.coord_system_id = cs_a.coord_system_id ' .
+                          'AND sr_c.coord_system_id = cs_c.coord_system_id ' .
+                          'AND  cs_a.attrib LIKE "%default_version%" ' .
+                          'AND  cs_c.attrib LIKE "%default_version%" ');
 
   $sth->execute();
 


### PR DESCRIPTION
set_toplevel  wrongfully assigns toplevel for seq_region,
if there's a part of it that was not includeded in the toplevel region.

i.e. AgamP4:
```
grep -e "AAAB01008980.1" -wF *agp -m 3
anopheles_gambiae_assembly_chromosome-scaffold.agp:3R   36259823        52563085        9       W  AAAB01008980.1   114704  16417966        +
anopheles_gambiae_assembly_scaffold-chunk.agp:AAAB01008980.1    1       50054   1       W       AAAB01008980_1      1       50054   +
anopheles_gambiae_assembly_scaffold-chunk.agp:AAAB01008980.1    50055   100108  2       W       AAAB01008980_2      1       50054   +
anopheles_gambiae_assembly_scaffold-chunk.agp:AAAB01008980.1    100109  150162  3       W       AAAB01008980_3      1       50054   +

grep 'AAAB01008980_' anopheles_gambiae_assembly_chromosome-chunk.agp -m 2
3R      36259823        36295281        727     W       AAAB01008980_3  14596   50054   +
3R      36295282        36345335        728     W       AAAB01008980_4  1       50054   +
```

When mapping  `AAAB01008980.1` to the `3R` chromosome
we're using sequence starting from the `114704` position.
Thus we have few chunks that are not used when mapping chunks to chromosome:
`AAAB01008980_1` and `AAAB01008980_2` are not used,
mapping starts with the `AAAB01008980_3`.
set_toplevel.pl iterates through the seq_level slices,
being unable to project unused `AAAB01008980_1` to the chromosome, it picks the topmost cs that it can project to: scaffold `AAAB01008980.1` and sets it to toplevel, ignoring the fact that other parts of `AAAB01008980.1` are included in to the `3R` chromosome.
